### PR TITLE
Fix macOS NIF build when LDFLAGS is set in environment

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -33,7 +33,7 @@ else ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -finline-functions -Wall
-	LDFLAGS ?= -flat_namespace -undefined suppress
+	LDFLAGS += -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes


### PR DESCRIPTION
## Summary

- Changes `LDFLAGS ?=` to `LDFLAGS +=` in the Darwin block of `c_src/Makefile`
- Ensures `-flat_namespace -undefined suppress` flags are always applied on macOS, even when `LDFLAGS` is already set in the environment

## Context

Homebrew PostgreSQL (and other packages) set `LDFLAGS` in shell profile config. The `?=` operator skips the macOS NIF flags when this happens, causing the build to fail with unresolved `enif_*` symbols.

Fixes #6